### PR TITLE
Remove `cgi.fix_pathinfo=0` as this is not default behaviour

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,7 @@ php5_file_uploads: 'On'
 php5_upload_max_filesize: '{{ php5_post_max_size }}'
 php5_max_file_uploads: 20
 php5_allow_url_fopen: 'On'
+php5_cgi_fix_pathinfo: '0'
 
 # Default values used in pools when pool has none set
 php5_default_pm: 'ondemand'

--- a/templates/etc/php5/fpm/php.ini.j2
+++ b/templates/etc/php5/fpm/php.ini.j2
@@ -775,7 +775,7 @@ enable_dl = Off
 ; http://php.net/cgi.redirect-status-env
 ;cgi.redirect_status_env = ;
 
- cgi.fix_pathinfo provides *real* PATH_INFO/PATH_TRANSLATED support for CGI.  PHP's
+; cgi.fix_pathinfo provides *real* PATH_INFO/PATH_TRANSLATED support for CGI.  PHP's
 ; previous behaviour was to set PATH_TRANSLATED to SCRIPT_FILENAME, and to not grok
 ; what PATH_INFO is.  For more information on PATH_INFO, see the cgi specs.  Setting
 ; this to 1 will cause PHP CGI to fix its paths to conform to the spec.  A setting

--- a/templates/etc/php5/fpm/php.ini.j2
+++ b/templates/etc/php5/fpm/php.ini.j2
@@ -773,17 +773,16 @@ enable_dl = Off
 ; will look for to know it is OK to continue execution.  Setting this variable MAY
 ; cause security issues, KNOW WHAT YOU ARE DOING FIRST.
 ; http://php.net/cgi.redirect-status-env
-;cgi.redirect_status_env = ; #}
+;cgi.redirect_status_env = ;
 
-{#
-; cgi.fix_pathinfo provides *real* PATH_INFO/PATH_TRANSLATED support for CGI.  PHP's
+ cgi.fix_pathinfo provides *real* PATH_INFO/PATH_TRANSLATED support for CGI.  PHP's
 ; previous behaviour was to set PATH_TRANSLATED to SCRIPT_FILENAME, and to not grok
 ; what PATH_INFO is.  For more information on PATH_INFO, see the cgi specs.  Setting
 ; this to 1 will cause PHP CGI to fix its paths to conform to the spec.  A setting
 ; of zero causes PHP to behave as before.  Default is 1.  You should fix your scripts
 ; to use SCRIPT_FILENAME rather than PATH_TRANSLATED.
 ; http://php.net/cgi.fix-pathinfo #}
-cgi.fix_pathinfo=0
+cgi.fix_pathinfo={{ php5_cgi_fix_pathinfo }}
 {#
 ; FastCGI under IIS (on WINNT based OS) supports the ability to impersonate
 ; security tokens of the calling client.  This allows IIS to define the


### PR DESCRIPTION
It took me hours to figure this one out. There is no way to run *FPM* with *lighttpd* when `cgi.fix_pathinfo` is `0`. Also, by default `cgi.fix_pathinfo` is set to `1`. I suggest to comment this statement and go with the default.