### PR TITLE
Add opcache settings as php should be run with opcache by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,14 @@ php5_max_file_uploads: 20
 php5_allow_url_fopen: 'On'
 php5_cgi_fix_pathinfo: '0'
 
+# Default values for the opcache
+php5_opcache_memory_consumption: 64
+#php5_opcache_interned_strings_buffer: 4
+php5_opcache_max_accelerated_files: 2000
+php5_opcache_revalidate_freq: 60
+#php5_opcache_blacklist_filename:
+#php5_opcache_error_log:
+
 # Default values used in pools when pool has none set
 php5_default_pm: 'ondemand'
 php5_default_pm_max_children: 5

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -122,8 +122,8 @@ php5_cgi_fix_pathinfo: '0'
 # .. envvar:: php5__opcache_enabled
 #
 # Enable the opcache extension
-php5__opcache_enabled: "ansible_distribution != 'Debian' and
-                        ansible_distribution_release != 'wheezy'"
+php5__opcache_enabled: "{{ ansible_distribution != 'Debian' and
+                        ansible_distribution_release != 'wheezy' }}"
 
 # .. envvar:: php5__opcache_memory_consumption
 #

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -48,6 +48,7 @@ php5_opcache_max_accelerated_files: 2000
 php5_opcache_revalidate_freq: 60
 #php5_opcache_blacklist_filename:
 #php5_opcache_error_log:
+php5__opcache_enabled: "ansible_distribution != 'Debian' and ansible_distribution_release != 'wheezy'"
 
 # Default values used in pools when pool has none set
 php5_default_pm: 'ondemand'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,11 +1,29 @@
 ---
-# Settings for socket permissions
-# Sockets have to be accessible by a webserver
+# Default variables
+# =================
+
+# .. contents:: Sections
+#    :local:
+
+# .. envvar:: php5_socket_listen_owner
+#
+# Owner of the ``php-fpm`` socket, must be accessible by the webserver
 php5_socket_listen_owner: 'www-data'
+
+# .. envvar:: php5_socket_listen_group
+#
+# Group of the ``php-fpm`` socket, must be accessible by the webserver
 php5_socket_listen_group: 'www-data'
+
+# .. envvar:: php5_socket_listen_mode
+#
+# Permission mode of the ``php-fpm`` socket
 php5_socket_listen_mode: '0660'
 
-# Memory limit
+# .. envvar:: php5_memory_limit
+#
+# This sets the maximum amount of memory in bytes that a script is allowed to
+# allocate.
 php5_memory_limit: '128M'
 
 # Install set of standard packages
@@ -26,51 +44,209 @@ php5_group_packages: []
 # List of packages to install on a given host.
 php5_host_packages: []
 
+# .. envvar:: php5_production
+#
 # This variable determines what options will be used in php.ini for options
 # that can be useful either in production or development environment
 php5_production: True
 
 # Default values for several global PHP5 options
+# .. envvar:: php5_max_execution_time
+#
+# This sets the maximum time in seconds a script is allowed to run before it
+# is terminated by the parser.
 php5_max_execution_time: '30'
+
+# .. envvar:: php5_max_input_time
+#
+# This sets the maximum time in seconds a script is allowed to parse input
+# data, like POST and GET.
 php5_max_input_time: '60'
+
+# .. envvar:: php5_post_max_size
+#
+# Sets max size of post data allowed. This setting also affects file upload.
+# An integer value is intrepreted as bytes. May also be specified with K, M or
+# G (with 1K = 1024 bytes). See also :ref:`php5_upload_max_filesize`.
 php5_post_max_size: '8M'
+
+# .. envvar:: php5_default_charset
+#
+# In PHP 5.6 onwards, "UTF-8" is the default value and its value is used as
+# the default character encoding for ``htmlentities()``,
+# ``html_entity_decode()`` and ``htmlspecialchars()`` if the encoding
+# parameter is omitted. The value of ``default_charset`` will also be used to
+# set the default character set for ``iconv`` functions if the
+# ``iconv.input_encoding``, ``iconv.output_encoding`` and
+# ``iconv.internal_encoding`` configuration options are unset, and for
+# ``mbstring`` functions if the ``mbstring.http_input``
+# ``mbstring.http_output`` ``mbstring.internal_encoding`` configuration option
+# is unset.
+#
+# All versions of PHP will use this value as the charset within the default
+# ``Content-Type`` header sent by PHP if the header isn't overridden by a call
+# to ``header()``.
 php5_default_charset: 'UTF-8'
+
+# .. envvar:: php5_file_uploads
+#
+# Whether or not to allow HTTP file uploads. See also
+# :ref:`php5_upload_max_filesize` and :ref:``php5_post_max_size``.
 php5_file_uploads: 'On'
+
+# .. envvar:: php5_upload_max_filesize
+#
+# The maximum size of an uploaded file. An integer value is intrepreted as
+# bytes. May also be specified with K, M or G (with 1K = 1024 bytes).
 php5_upload_max_filesize: '{{ php5_post_max_size }}'
+
+# .. envvar:: php5_max_file_uploads
+#
+# The maximum number of files allowed to be uploaded simultaneously.
 php5_max_file_uploads: 20
+
+# .. envvar:: php5_allow_url_fopen
+#
+# This option enables the URL-aware fopen wrappers that enable accessing URL
+# object like files.
 php5_allow_url_fopen: 'On'
+
+# .. envvar:: php5_cgi_fix_pathinfo
+#
+# Setting this to 1 will cause PHP CGI to fix its paths to conform to the CGI
+# spec. Has to be set to 1 for ``lighttpd``.
 php5_cgi_fix_pathinfo: '0'
 
 # Default values for the opcache
-php5__opcache_enabled: "ansible_distribution != 'Debian' and ansible_distribution_release != 'wheezy'"
+
+# .. envvar:: php5__opcache_enabled
+#
+# Enable the opcache extension
+php5__opcache_enabled: "ansible_distribution != 'Debian' and
+                        ansible_distribution_release != 'wheezy'"
+
+# .. envvar:: php5__opcache_memory_consumption
+#
+# The OPcache shared memory storage size.
 php5__opcache_memory_consumption: '{{ (memcached_memory_available  | float *
                                        memcached_memory_multiplier | float) | int }}'
+
+# .. envvar:: php5__opcache_memory_available
+#
+# Amount of RAM which ``debops.php5`` takes into account while calculating
+# :ref:`php5__opcache_memory_consumption` variable.
 php5__opcache_memory_available: '{{ ansible_memtotal_mb }}'
+
+# .. envvar:: php5__opcache_memory_multiplier
+#
+# Value which is multiplied by amount of available RAM to limit memory
+# accessible to ``php5-opcache``. 1.0 will allow access to all available
+# memory, values bigger than 1.0 don't make much sense.
 php5__opcache_memory_multiplier: '0.03'
+
+# .. envvar:: php5__opcache_interned_strings_buffer
+#
+# The amount of memory for interned strings in MBytes.
 #php5__opcache_interned_strings_buffer: 4
+
+# .. envvar:: php5__opcache_max_accelerated_files
+#
+# The maximum number of keys (scripts) in the OPcache hash table.
+# Only numbers between 200 and 100000 are allowed.
 php5__opcache_max_accelerated_files: 2000
+
+# .. envvar:: php5__opcache_revalidate_freq
+#
+# How often (in seconds) to check file timestamps for changes to the shared
+# memory storage allocation.
 php5__opcache_revalidate_freq: 60
+
+# .. envvar:: php5__opcache_blacklist_filename
+#
+# The location of the OPcache blacklist file.
 #php5__opcache_blacklist_filename:
+
+# .. envvar:: php5__opcache_error_log
+#
+# OPcache error_log file name. If not set, `stderr` is assumed.
 #php5__opcache_error_log:
 
 # Default values used in pools when pool has none set
+
+# .. envvar:: php5_default_pm
+#
+#
 php5_default_pm: 'ondemand'
+
+# .. envvar:: php5_default_pm_max_children
+#
+#
 php5_default_pm_max_children: 5
+
+# .. envvar:: php5_default_pm_min_spare_servers
+#
+#
 php5_default_pm_min_spare_servers: 1
+
+# .. envvar:: php5_default_pm_max_spare_servers
+#
+#
 php5_default_pm_max_spare_servers: 3
+
+# .. envvar:: php5_default_pm_start_servers
+#
+#
 php5_default_pm_start_servers: 2
+
+# .. envvar:: php5_default_pm_process_idle_timeout
+#
+#
 php5_default_pm_process_idle_timeout: '10s'
+
+# .. envvar:: php5_default_pm_max_requests
+#
+#
 php5_default_pm_max_requests: 500
+
+# .. envvar:: php5_default_pm_status
+#
+#
 php5_default_pm_status: False
+
+# .. envvar:: php5_default_pm_status_path
+#
+#
 php5_default_pm_status_path: '/php5_status'
+
+# .. envvar:: php5_default_ping_path
+#
+#
 php5_default_ping_path: '/php5_ping'
+
+# .. envvar:: php5_default_ping_response
+#
+#
 php5_default_ping_response: 'pong'
+
+# .. envvar:: php5_default_rlimit_files
+#
+#
 php5_default_rlimit_files: 1024
+
+# .. envvar:: php5_default_rlimit_core
+#
+#
 php5_default_rlimit_core: 0
 
+
+# .. envvar:: php5_manage_pools
+#
 # Should php5 role manage server pools?
 php5_manage_pools: True
 
+
+# .. envvar:: php5_pools
+#
 # List of managed pools
 php5_pools: [ '{{ php5_pool_default }}' ]
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -128,8 +128,8 @@ php5__opcache_enabled: "{{ ansible_distribution != 'Debian' and
 # .. envvar:: php5__opcache_memory_consumption
 #
 # The OPcache shared memory storage size.
-php5__opcache_memory_consumption: '{{ (memcached_memory_available  | float *
-                                       memcached_memory_multiplier | float) | int }}'
+php5__opcache_memory_consumption: '{{ (php5__opcache_memory_available  | float *
+                                       php5__opcache_memory_multiplier | float) | int }}'
 
 # .. envvar:: php5__opcache_memory_available
 #

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -42,13 +42,16 @@ php5_allow_url_fopen: 'On'
 php5_cgi_fix_pathinfo: '0'
 
 # Default values for the opcache
-php5_opcache_memory_consumption: 64
-#php5_opcache_interned_strings_buffer: 4
-php5_opcache_max_accelerated_files: 2000
-php5_opcache_revalidate_freq: 60
-#php5_opcache_blacklist_filename:
-#php5_opcache_error_log:
 php5__opcache_enabled: "ansible_distribution != 'Debian' and ansible_distribution_release != 'wheezy'"
+php5__opcache_memory_consumption: '{{ (memcached_memory_available  | float *
+                                       memcached_memory_multiplier | float) | int }}'
+php5__opcache_memory_available: '{{ ansible_memtotal_mb }}'
+php5__opcache_memory_multiplier: '0.03'
+#php5__opcache_interned_strings_buffer: 4
+php5__opcache_max_accelerated_files: 2000
+php5__opcache_revalidate_freq: 60
+#php5__opcache_blacklist_filename:
+#php5__opcache_error_log:
 
 # Default values used in pools when pool has none set
 php5_default_pm: 'ondemand'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,6 +54,14 @@
     mode: '0644'
   notify: Restart php5-fpm
 
+- name: Ensure mods-available directory exists
+  file:
+    path: /etc/php5/mods-available/
+    owner: root
+    group: root
+    mode: 0755
+    state: directory
+
 - include: opcache.yml
   when: php5__opcache_enabled|bool
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -54,6 +54,9 @@
     mode: '0644'
   notify: Restart php5-fpm
 
+- include: opcache.yml
+  when: ansible_distribution != 'Debian' and ansible_distribution_release != 'wheezy'
+
 - name: Check if pool-available.d/ directory exists
   stat:
     path: '/etc/php5/fpm/pool-available.d'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,6 +65,17 @@
 - include: opcache.yml
   when: php5__opcache_enabled|bool
 
+- name: Ensure mods-available directory exists
+  file:
+    path: /etc/php5/mods-available/
+    owner: root
+    group: root
+    mode: 0755
+    state: directory
+
+- include: opcache.yml
+  when: php5__opcache_enabled|bool
+
 - name: Check if pool-available.d/ directory exists
   stat:
     path: '/etc/php5/fpm/pool-available.d'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,7 +55,7 @@
   notify: Restart php5-fpm
 
 - include: opcache.yml
-  when: ansible_distribution != 'Debian' and ansible_distribution_release != 'wheezy'
+  when: php5__opcache_enabled|bool
 
 - name: Check if pool-available.d/ directory exists
   stat:

--- a/tasks/opcache.yml
+++ b/tasks/opcache.yml
@@ -25,6 +25,7 @@
     state: link
     src: ../../mods-available/opcache.ini
     dest: /etc/php5/fpm/conf.d/05-opcache.ini
+    force: yes
   when: php5_php5enmod|failed
   notify: Restart php5-fpm
 

--- a/tasks/opcache.yml
+++ b/tasks/opcache.yml
@@ -1,0 +1,30 @@
+---
+- name: Copy opcache config
+  template:
+    src: etc/php5/mods-available/opcache.ini.j2
+    dest: /etc/php5/mods-available/opcache.ini
+    owner: root
+    group: root
+    mode: 0644
+    backup: True
+  notify: Restart php5-fpm
+
+- name: Check for php5enmod
+  command: 'which php5enmod'
+  register: php5_php5enmod
+  failed_when: False
+  changed_when: False
+
+- name: Enable opcache
+  command: 'php5enmod -s fpm opcache'
+  when: php5_php5enmod|success
+  notify: Restart php5-fpm
+
+- name: Enable opcache
+  file:
+    state: link
+    src: ../../mods-available/opcache.ini
+    dest: /etc/php5/fpm/conf.d/05-opcache.ini
+  when: php5_php5enmod|failed
+  notify: Restart php5-fpm
+

--- a/templates/etc/php5/mods-available/opcache.ini.j2
+++ b/templates/etc/php5/mods-available/opcache.ini.j2
@@ -10,14 +10,14 @@ opcache.enable=1
 ;opcache.enable_cli=0
 
 ; The OPcache shared memory storage size.
-opcache.memory_consumption={{ php5_opcache_memory_consumption }}
+opcache.memory_consumption={{ php5__opcache_memory_consumption }}
 
 ; The amount of memory for interned strings in Mbytes.
-opcache.interned_strings_buffer={{ php5_opcache_interned_strings_buffer|default('4') }}
+opcache.interned_strings_buffer={{ php5__opcache_interned_strings_buffer|default('4') }}
 
 ; The maximum number of keys (scripts) in the OPcache hash table.
 ; Only numbers between 200 and 100000 are allowed.
-opcache.max_accelerated_files={{ php5_opcache_max_accelerated_files }}
+opcache.max_accelerated_files={{ php5__opcache_max_accelerated_files }}
 
 ; The maximum percentage of "wasted" memory until a restart is scheduled.
 ;opcache.max_wasted_percentage=5
@@ -35,7 +35,7 @@ opcache.validate_timestamps={% if php5_production is defined and php5_production
 ; How often (in seconds) to check file timestamps for changes to the shared
 ; memory storage allocation. ("1" means validate once per second, but only
 ; once per request. "0" means always validate)
-opcache.revalidate_freq={{ php5_opcache_revalidate_freq }}
+opcache.revalidate_freq={{ php5__opcache_revalidate_freq }}
 
 ; Enables or disables file search in include_path optimization
 ;opcache.revalidate_path=0
@@ -68,8 +68,8 @@ opcache.fast_shutdown=0
 ; to a new line. The filename may be a full path or just a file prefix
 ; (i.e., /var/www/x  blacklists all the files and directories in /var/www
 ; that start with 'x'). Line starting with a ; are ignored (comments).
-{% if php5_opcache_blacklist_filename is defined %}
-opcache.blacklist_filename={{ php5_opcache_blacklist_filename }}
+{% if php5__opcache_blacklist_filename is defined %}
+opcache.blacklist_filename={{ php5__opcache_blacklist_filename }}
 {% else %}
 ;opcache.blacklist_filename=
 {% endif %}
@@ -87,8 +87,8 @@ opcache.blacklist_filename={{ php5_opcache_blacklist_filename }}
 ;opcache.force_restart_timeout=180
 
 ; OPcache error_log file name. Empty string assumes "stderr".
-{% if php5_opcache_error_log is defined %}
-opcache.error_log={{ php5_opcache_error_log }}
+{% if php5__opcache_error_log is defined %}
+opcache.error_log={{ php5__opcache_error_log }}
 {% else %}
 ;opcache.error_log=
 {% endif %}

--- a/templates/etc/php5/mods-available/opcache.ini.j2
+++ b/templates/etc/php5/mods-available/opcache.ini.j2
@@ -1,0 +1,108 @@
+; configuration for php ZendOpcache module
+; priority=05
+zend_extension=opcache.so
+
+[opcache]
+; Determines if Zend OPCache is enabled
+opcache.enable=1
+
+; Determines if Zend OPCache is enabled for the CLI version of PHP
+;opcache.enable_cli=0
+
+; The OPcache shared memory storage size.
+opcache.memory_consumption={{ php5_opcache_memory_consumption }}
+
+; The amount of memory for interned strings in Mbytes.
+opcache.interned_strings_buffer={{ php5_opcache_interned_strings_buffer|default('4') }}
+
+; The maximum number of keys (scripts) in the OPcache hash table.
+; Only numbers between 200 and 100000 are allowed.
+opcache.max_accelerated_files={{ php5_opcache_max_accelerated_files }}
+
+; The maximum percentage of "wasted" memory until a restart is scheduled.
+;opcache.max_wasted_percentage=5
+
+; When this directive is enabled, the OPcache appends the current working
+; directory to the script key, thus eliminating possible collisions between
+; files with the same name (basename). Disabling the directive improves
+; performance, but may break existing applications.
+;opcache.use_cwd=1
+
+; When disabled, you must reset the OPcache manually or restart the
+; webserver for changes to the filesystem to take effect.
+opcache.validate_timestamps={% if php5_production is defined and php5_production %}0{% else %}1{% endif %}
+
+; How often (in seconds) to check file timestamps for changes to the shared
+; memory storage allocation. ("1" means validate once per second, but only
+; once per request. "0" means always validate)
+opcache.revalidate_freq={{ php5_opcache_revalidate_freq }}
+
+; Enables or disables file search in include_path optimization
+;opcache.revalidate_path=0
+
+; If disabled, all PHPDoc comments are dropped from the code to reduce the
+; size of the optimized code.
+;opcache.save_comments=1
+
+; If disabled, PHPDoc comments are not loaded from SHM, so "Doc Comments"
+; may be always stored (save_comments=1), but not loaded by applications
+; that don't need them anyway.
+;opcache.load_comments=1
+
+; If enabled, a fast shutdown sequence is used for the accelerated code
+opcache.fast_shutdown=0
+
+; Allow file existence override (file_exists, etc.) performance feature.
+;opcache.enable_file_override=0
+
+; A bitmask, where each bit enables or disables the appropriate OPcache
+; passes
+;opcache.optimization_level=0xffffffff
+
+;opcache.inherited_hack=1
+;opcache.dups_fix=0
+
+; The location of the OPcache blacklist file (wildcards allowed).
+; Each OPcache blacklist file is a text file that holds the names of files
+; that should not be accelerated. The file format is to add each filename
+; to a new line. The filename may be a full path or just a file prefix
+; (i.e., /var/www/x  blacklists all the files and directories in /var/www
+; that start with 'x'). Line starting with a ; are ignored (comments).
+{% if php5_opcache_blacklist_filename is defined %}
+opcache.blacklist_filename={{ php5_opcache_blacklist_filename }}
+{% else %}
+;opcache.blacklist_filename=
+{% endif %}
+
+; Allows exclusion of large files from being cached. By default all files
+; are cached.
+;opcache.max_file_size=0
+
+; Check the cache checksum each N requests.
+; The default value of "0" means that the checks are disabled.
+;opcache.consistency_checks=0
+
+; How long to wait (in seconds) for a scheduled restart to begin if the cache
+; is not being accessed.
+;opcache.force_restart_timeout=180
+
+; OPcache error_log file name. Empty string assumes "stderr".
+{% if php5_opcache_error_log is defined %}
+opcache.error_log={{ php5_opcache_error_log }}
+{% else %}
+;opcache.error_log=
+{% endif %}
+
+; All OPcache errors go to the Web server log.
+; By default, only fatal errors (level 0) or errors (level 1) are logged.
+; You can also enable warnings (level 2), info messages (level 3) or
+; debug messages (level 4).
+;opcache.log_verbosity_level=1
+
+; Preferred Shared Memory back-end. Leave empty and let the system decide.
+;opcache.preferred_memory_model=
+
+; Protect the shared memory from unexpected writing during script execution.
+; Useful for internal debugging only.
+;opcache.protect_memory=0
+


### PR DESCRIPTION
Since php-fpm is usually run with opcache, I thought it might be a nice feature to have it installed by default.
